### PR TITLE
Change GitHub api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This action will set / delete Branch Protection rules on specified branches of G
     "enforce_admins": true,
     "required_linear_history": true,
     "required_pull_request_reviews": {
-        "dismiss_stale_reviews": true
+      "dismiss_stale_reviews": true
     }
   },
   "main": {
@@ -40,7 +40,7 @@ This action will set / delete Branch Protection rules on specified branches of G
     "enforce_admins": null,
     "required_linear_history": null,
     "required_pull_request_reviews": {
-    "dismiss_stale_reviews": true
+      "dismiss_stale_reviews": true
     }
   }
 }
@@ -53,9 +53,12 @@ This action will set / delete Branch Protection rules on specified branches of G
 **Description** - Path of the text file(.txt) with repos to be excluded from branch protection. Specify every repo name (without org/ prefix) on a new line. This is optional. If not provided, no repos will be excluded and branch protection will be applied on all the repos within the organization.
 
 ### `action`
-**Description** - This GitHub Custom action can be used to set / delete branch protection. The default value is set (if not specified). If delete is assigned, it will remove branch protection from every repo, if branch protection is already applied.
-**Default** - 'set'  
+**Description** - This GitHub Custom action can be used to set / add / delete branch protection. The default value is set (if not specified). If add is assigned, it will add branch protection to every repo, if branch protection is not applied. If delete is assigned, it will remove branch protection from every repo, if branch protection is already applied.
+**Default** - 'set'
 
+### `ghBaseUrl`
+**Description** - Base URL of GitHub API. The default value is "https://api.github.com".
+**Default** - 'https://api.github.com'  
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ This action will set / delete Branch Protection rules on specified branches of G
 **Description** - This GitHub Custom action can be used to set / add / delete branch protection. The default value is set (if not specified). If add is assigned, it will add branch protection to every repo, if branch protection is not applied. If delete is assigned, it will remove branch protection from every repo, if branch protection is already applied.
 **Default** - 'set'
 
-### `ghBaseUrl`
-**Description** - Base URL of GitHub API. The default value is "https://api.github.com".
-**Default** - 'https://api.github.com'  
 
 # Usage
 

--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,6 @@ inputs:
     description: 'Set or Add or Delete Branch protection. Default is set.'
     default: 'set'
     required: true
-  ghBaseUrl:
-    description: 'Set base URL of GitHub API. Default is "https://api.github.com".'
-    default: 'https://api.github.com'
 
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,12 @@ inputs:
   excludedReposPath:
     description: 'Path of the file with repos (newline separated) to be excluded for branch protection. This is optional.'
   action:
-    description: 'Set or Delete Branch protection. Default is set.'
+    description: 'Set or Add or Delete Branch protection. Default is set.'
     default: 'set'
     required: true
+  ghBaseUrl:
+    description: 'Set base URL of GitHub API. Default is "https://api.github.com".'
+    default: 'https://api.github.com'
 
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
   
 branding:

--- a/dist/index.js
+++ b/dist/index.js
@@ -3100,7 +3100,7 @@ var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const core = __nccwpck_require__(186);
-const { request: orgRequest } = __nccwpck_require__(234);
+const { request } = __nccwpck_require__(234);
 const fs = __nccwpck_require__(747)
 
 var excludedReposPath = '';
@@ -3113,43 +3113,29 @@ async function run() {
     excludedReposPath = core.getInput("excludedReposPath");
     includedReposPath = core.getInput("includedReposPath");
     const action = core.getInput("action");
-    const canDeleteProtection = action == 'set' || action == 'delete';
-    const canSetProtection = action == 'set' || action == 'add';
-
+    const limit = 100;
     var rulesObj;
     var branches;
     try {
         if(!fs.existsSync(rulesPath)){
             throw "Rules JSON is missing."
         }
-
-        const request = orgRequest.defaults({
-            baseUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
-            headers: {
-                authorization: "token " + token,
-            },
-        })
         const rules = fs.readFileSync(rulesPath, {encoding:'utf8', flag:'r'});
         rulesObj = JSON.parse(rules);
         keys = Object.keys(rulesObj);
-        var repos = await getFinalRepos(request, orgName);  
+        var repos = await getFinalRepos(token, orgName);  
         for (let i = 0; i < repos.length; i++) {
-            branches = await getBranches(request, repos[i], keys);  
+            branches = await getBranches(token, repos[i], keys);  
             for (let j = 0; j < branches.length; j++) {
                 if(branches[j].protected){
-                    if (!canDeleteProtection) {
-                        console.log("Skip Branch Protection for " + branches[j].name + " branch of " + repos[i]);
-                        continue;
-                    }
-
                     console.log("Deleting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
                     core.debug("Deleting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
-                    await deleteProtection(request, repos[i], branches[j].name);
+                    await deleteProtection(token, repos[i], branches[j].name);
                 }
-                if(canSetProtection){
+                if(action == "set"){
                     console.log("Setting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
                     core.debug("Setting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
-                    await setProtection(request, repos[i], branches[j].name, rulesObj[branches[j].name] )
+                    await setProtection(token, repos[i], branches[j].name, rulesObj[branches[j].name] )
                 }
             }     
         }
@@ -3160,7 +3146,7 @@ async function run() {
   }
 }
 
-async function setProtection(request, repoName, branchName, ruleData){
+async function setProtection(token, repoName, branchName, ruleData){
     const url = "/repos/" + repoName + "/branches/" + branchName + "/protection"
     if(ruleData == ""){
         ruleData = {
@@ -3173,6 +3159,9 @@ async function setProtection(request, repoName, branchName, ruleData){
     }
     try {
         const result = await request("PUT " + url, {
+            headers: {
+            authorization: "token " + token,
+            },
             data: ruleData
         });
         //console.log(result.data);
@@ -3184,10 +3173,14 @@ async function setProtection(request, repoName, branchName, ruleData){
     }
 }
 
-async function deleteProtection(request, repoName, branchName){
+async function deleteProtection(token, repoName, branchName){
     const url = "/repos/" + repoName + "/branches/" + branchName + "/protection"
     try{
-        const result = await request("DELETE " + url);
+        const result = await request("DELETE " + url, {
+            headers: {
+            authorization: "token " + token,
+            }
+        });
         if(result.status != 204){
             throw "Exception occured during Delete Protection";
         }
@@ -3198,11 +3191,15 @@ async function deleteProtection(request, repoName, branchName){
     }
 }
 
-async function getBranches(request, repoName, branchNames){
+async function getBranches(token, repoName, branchNames){
     branchInfoArr = [];
     const url = "/repos/" + repoName + "/branches"
     try {
-        const result = await request("GET " + url);
+        const result = await request("GET " + url, {
+            headers: {
+            authorization: "token " + token,
+            }
+        });
         branchData = result.data;
         for (let j = 0; j < branchData.length; j++) {
             const element = branchData[j];
@@ -3218,10 +3215,13 @@ async function getBranches(request, repoName, branchNames){
     return branchInfoArr;
 }
 
-async function getRepoCount(request, orgName){
+async function getRepoCount(token, orgName){
     repoCnt = 0;
     try {
         const result = await request("GET /orgs/{org}/repos", {
+            headers: {
+            authorization: "token " + token,
+            },
             org: orgName,
             per_page:1,
             type: "all"
@@ -3241,10 +3241,13 @@ function getPageCount(itemCount, limit){
     return pageCount;
 }
 
-async function getPagedRepos(request, orgName, pageNum, limit){
+async function getPagedRepos(token, orgName, pageNum, limit){
     var repos = [];
     try {
         const result = await request("GET /orgs/{org}/repos", {
+            headers: {
+            authorization: "token " + token,
+            },
             org: orgName,
             per_page:limit,
             type: "all",
@@ -3261,7 +3264,7 @@ async function getPagedRepos(request, orgName, pageNum, limit){
     return repos;
 }
 
-async function getFinalRepos(request, orgName){
+async function getFinalRepos(token, orgName){
     repos = [];
     includedRepos = [];
     limit = 100;
@@ -3273,12 +3276,12 @@ async function getFinalRepos(request, orgName){
             }
             return includedRepos;
         }
-        repoCount = await getRepoCount(request, orgName); 
+        repoCount = await getRepoCount(token, orgName); 
         pageCnt = getPageCount(repoCount, limit);
         excludedRepos = getReposFromFile(excludedReposPath);
         for (let i = 0; i < pageCnt; i++) {
             i = i + 1;
-            pagedRepos = await getPagedRepos(request, orgName, i, limit);
+            pagedRepos = await getPagedRepos(token, orgName, i, limit);
             for (let j = 0; j < pagedRepos.length; j++) {
                 repoShortName = pagedRepos[j].replace(orgName + "/","");
                 if(!excludedRepos.includes(repoShortName)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3100,7 +3100,7 @@ var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
 const core = __nccwpck_require__(186);
-const { request } = __nccwpck_require__(234);
+const { request: orgRequest } = __nccwpck_require__(234);
 const fs = __nccwpck_require__(747)
 
 var excludedReposPath = '';
@@ -3113,29 +3113,44 @@ async function run() {
     excludedReposPath = core.getInput("excludedReposPath");
     includedReposPath = core.getInput("includedReposPath");
     const action = core.getInput("action");
-    const limit = 100;
+    const baseUrl = core.getInput("ghBaseUrl");
+    const canDeleteProtection = action == 'set' || action == 'delete';
+    const canSetProtection = action == 'set' || action == 'add';
+
     var rulesObj;
     var branches;
     try {
         if(!fs.existsSync(rulesPath)){
             throw "Rules JSON is missing."
         }
+
+        const request = orgRequest.defaults({
+            baseUrl: baseUrl,
+            headers: {
+                authorization: "token " + token,
+            },
+        })
         const rules = fs.readFileSync(rulesPath, {encoding:'utf8', flag:'r'});
         rulesObj = JSON.parse(rules);
         keys = Object.keys(rulesObj);
-        var repos = await getFinalRepos(token, orgName);  
+        var repos = await getFinalRepos(request, orgName);  
         for (let i = 0; i < repos.length; i++) {
-            branches = await getBranches(token, repos[i], keys);  
+            branches = await getBranches(request, repos[i], keys);  
             for (let j = 0; j < branches.length; j++) {
                 if(branches[j].protected){
+                    if (!canDeleteProtection) {
+                        console.log("Skip Branch Protection for " + branches[j].name + " branch of " + repos[i]);
+                        continue;
+                    }
+
                     console.log("Deleting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
                     core.debug("Deleting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
-                    await deleteProtection(token, repos[i], branches[j].name);
+                    await deleteProtection(request, repos[i], branches[j].name);
                 }
-                if(action == "set"){
+                if(canSetProtection){
                     console.log("Setting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
                     core.debug("Setting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
-                    await setProtection(token, repos[i], branches[j].name, rulesObj[branches[j].name] )
+                    await setProtection(request, repos[i], branches[j].name, rulesObj[branches[j].name] )
                 }
             }     
         }
@@ -3146,7 +3161,7 @@ async function run() {
   }
 }
 
-async function setProtection(token, repoName, branchName, ruleData){
+async function setProtection(request, repoName, branchName, ruleData){
     const url = "/repos/" + repoName + "/branches/" + branchName + "/protection"
     if(ruleData == ""){
         ruleData = {
@@ -3159,9 +3174,6 @@ async function setProtection(token, repoName, branchName, ruleData){
     }
     try {
         const result = await request("PUT " + url, {
-            headers: {
-            authorization: "token " + token,
-            },
             data: ruleData
         });
         //console.log(result.data);
@@ -3173,14 +3185,10 @@ async function setProtection(token, repoName, branchName, ruleData){
     }
 }
 
-async function deleteProtection(token, repoName, branchName){
+async function deleteProtection(request, repoName, branchName){
     const url = "/repos/" + repoName + "/branches/" + branchName + "/protection"
     try{
-        const result = await request("DELETE " + url, {
-            headers: {
-            authorization: "token " + token,
-            }
-        });
+        const result = await request("DELETE " + url);
         if(result.status != 204){
             throw "Exception occured during Delete Protection";
         }
@@ -3191,15 +3199,11 @@ async function deleteProtection(token, repoName, branchName){
     }
 }
 
-async function getBranches(token, repoName, branchNames){
+async function getBranches(request, repoName, branchNames){
     branchInfoArr = [];
     const url = "/repos/" + repoName + "/branches"
     try {
-        const result = await request("GET " + url, {
-            headers: {
-            authorization: "token " + token,
-            }
-        });
+        const result = await request("GET " + url);
         branchData = result.data;
         for (let j = 0; j < branchData.length; j++) {
             const element = branchData[j];
@@ -3215,13 +3219,10 @@ async function getBranches(token, repoName, branchNames){
     return branchInfoArr;
 }
 
-async function getRepoCount(token, orgName){
+async function getRepoCount(request, orgName){
     repoCnt = 0;
     try {
         const result = await request("GET /orgs/{org}/repos", {
-            headers: {
-            authorization: "token " + token,
-            },
             org: orgName,
             per_page:1,
             type: "all"
@@ -3241,13 +3242,10 @@ function getPageCount(itemCount, limit){
     return pageCount;
 }
 
-async function getPagedRepos(token, orgName, pageNum, limit){
+async function getPagedRepos(request, orgName, pageNum, limit){
     var repos = [];
     try {
         const result = await request("GET /orgs/{org}/repos", {
-            headers: {
-            authorization: "token " + token,
-            },
             org: orgName,
             per_page:limit,
             type: "all",
@@ -3264,7 +3262,7 @@ async function getPagedRepos(token, orgName, pageNum, limit){
     return repos;
 }
 
-async function getFinalRepos(token, orgName){
+async function getFinalRepos(request, orgName){
     repos = [];
     includedRepos = [];
     limit = 100;
@@ -3276,12 +3274,12 @@ async function getFinalRepos(token, orgName){
             }
             return includedRepos;
         }
-        repoCount = await getRepoCount(token, orgName); 
+        repoCount = await getRepoCount(request, orgName); 
         pageCnt = getPageCount(repoCount, limit);
         excludedRepos = getReposFromFile(excludedReposPath);
         for (let i = 0; i < pageCnt; i++) {
             i = i + 1;
-            pagedRepos = await getPagedRepos(token, orgName, i, limit);
+            pagedRepos = await getPagedRepos(request, orgName, i, limit);
             for (let j = 0; j < pagedRepos.length; j++) {
                 repoShortName = pagedRepos[j].replace(orgName + "/","");
                 if(!excludedRepos.includes(repoShortName)) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3113,7 +3113,6 @@ async function run() {
     excludedReposPath = core.getInput("excludedReposPath");
     includedReposPath = core.getInput("includedReposPath");
     const action = core.getInput("action");
-    const baseUrl = core.getInput("ghBaseUrl");
     const canDeleteProtection = action == 'set' || action == 'delete';
     const canSetProtection = action == 'set' || action == 'add';
 
@@ -3125,7 +3124,7 @@ async function run() {
         }
 
         const request = orgRequest.defaults({
-            baseUrl: baseUrl,
+            baseUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
             headers: {
                 authorization: "token " + token,
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "branch-protection",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branch-protection",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Custom GitHub Action based on Node.js to set branch protection rules",
   "main": "dist/index.js",
   "scripts": {

--- a/src/action.js
+++ b/src/action.js
@@ -12,7 +12,6 @@ async function run() {
     excludedReposPath = core.getInput("excludedReposPath");
     includedReposPath = core.getInput("includedReposPath");
     const action = core.getInput("action");
-    const baseUrl = core.getInput("ghBaseUrl");
     const canDeleteProtection = action == 'set' || action == 'delete';
     const canSetProtection = action == 'set' || action == 'add';
 
@@ -24,7 +23,7 @@ async function run() {
         }
 
         const request = orgRequest.defaults({
-            baseUrl: baseUrl,
+            baseUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
             headers: {
                 authorization: "token " + token,
             },

--- a/src/action.js
+++ b/src/action.js
@@ -1,5 +1,5 @@
 const core = require('@actions/core');
-const { request } = require("@octokit/request");
+const { request: orgRequest } = require("@octokit/request");
 const fs = require('fs')
 
 var excludedReposPath = '';
@@ -12,29 +12,44 @@ async function run() {
     excludedReposPath = core.getInput("excludedReposPath");
     includedReposPath = core.getInput("includedReposPath");
     const action = core.getInput("action");
-    const limit = 100;
+    const baseUrl = core.getInput("ghBaseUrl");
+    const canDeleteProtection = action == 'set' || action == 'delete';
+    const canSetProtection = action == 'set' || action == 'add';
+
     var rulesObj;
     var branches;
     try {
         if(!fs.existsSync(rulesPath)){
             throw "Rules JSON is missing."
         }
+
+        const request = orgRequest.defaults({
+            baseUrl: baseUrl,
+            headers: {
+                authorization: "token " + token,
+            },
+        })
         const rules = fs.readFileSync(rulesPath, {encoding:'utf8', flag:'r'});
         rulesObj = JSON.parse(rules);
         keys = Object.keys(rulesObj);
-        var repos = await getFinalRepos(token, orgName);  
+        var repos = await getFinalRepos(request, orgName);  
         for (let i = 0; i < repos.length; i++) {
-            branches = await getBranches(token, repos[i], keys);  
+            branches = await getBranches(request, repos[i], keys);  
             for (let j = 0; j < branches.length; j++) {
                 if(branches[j].protected){
+                    if (!canDeleteProtection) {
+                        console.log("Skip Branch Protection for " + branches[j].name + " branch of " + repos[i]);
+                        continue;
+                    }
+
                     console.log("Deleting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
                     core.debug("Deleting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
-                    await deleteProtection(token, repos[i], branches[j].name);
+                    await deleteProtection(request, repos[i], branches[j].name);
                 }
-                if(action == "set"){
+                if(canSetProtection){
                     console.log("Setting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
                     core.debug("Setting Branch Protection for " + branches[j].name + " branch of " + repos[i]);
-                    await setProtection(token, repos[i], branches[j].name, rulesObj[branches[j].name] )
+                    await setProtection(request, repos[i], branches[j].name, rulesObj[branches[j].name] )
                 }
             }     
         }
@@ -45,7 +60,7 @@ async function run() {
   }
 }
 
-async function setProtection(token, repoName, branchName, ruleData){
+async function setProtection(request, repoName, branchName, ruleData){
     const url = "/repos/" + repoName + "/branches/" + branchName + "/protection"
     if(ruleData == ""){
         ruleData = {
@@ -58,9 +73,6 @@ async function setProtection(token, repoName, branchName, ruleData){
     }
     try {
         const result = await request("PUT " + url, {
-            headers: {
-            authorization: "token " + token,
-            },
             data: ruleData
         });
         //console.log(result.data);
@@ -72,14 +84,10 @@ async function setProtection(token, repoName, branchName, ruleData){
     }
 }
 
-async function deleteProtection(token, repoName, branchName){
+async function deleteProtection(request, repoName, branchName){
     const url = "/repos/" + repoName + "/branches/" + branchName + "/protection"
     try{
-        const result = await request("DELETE " + url, {
-            headers: {
-            authorization: "token " + token,
-            }
-        });
+        const result = await request("DELETE " + url);
         if(result.status != 204){
             throw "Exception occured during Delete Protection";
         }
@@ -90,15 +98,11 @@ async function deleteProtection(token, repoName, branchName){
     }
 }
 
-async function getBranches(token, repoName, branchNames){
+async function getBranches(request, repoName, branchNames){
     branchInfoArr = [];
     const url = "/repos/" + repoName + "/branches"
     try {
-        const result = await request("GET " + url, {
-            headers: {
-            authorization: "token " + token,
-            }
-        });
+        const result = await request("GET " + url);
         branchData = result.data;
         for (let j = 0; j < branchData.length; j++) {
             const element = branchData[j];
@@ -114,13 +118,10 @@ async function getBranches(token, repoName, branchNames){
     return branchInfoArr;
 }
 
-async function getRepoCount(token, orgName){
+async function getRepoCount(request, orgName){
     repoCnt = 0;
     try {
         const result = await request("GET /orgs/{org}/repos", {
-            headers: {
-            authorization: "token " + token,
-            },
             org: orgName,
             per_page:1,
             type: "all"
@@ -140,13 +141,10 @@ function getPageCount(itemCount, limit){
     return pageCount;
 }
 
-async function getPagedRepos(token, orgName, pageNum, limit){
+async function getPagedRepos(request, orgName, pageNum, limit){
     var repos = [];
     try {
         const result = await request("GET /orgs/{org}/repos", {
-            headers: {
-            authorization: "token " + token,
-            },
             org: orgName,
             per_page:limit,
             type: "all",
@@ -163,7 +161,7 @@ async function getPagedRepos(token, orgName, pageNum, limit){
     return repos;
 }
 
-async function getFinalRepos(token, orgName){
+async function getFinalRepos(request, orgName){
     repos = [];
     includedRepos = [];
     limit = 100;
@@ -175,12 +173,12 @@ async function getFinalRepos(token, orgName){
             }
             return includedRepos;
         }
-        repoCount = await getRepoCount(token, orgName); 
+        repoCount = await getRepoCount(request, orgName); 
         pageCnt = getPageCount(repoCount, limit);
         excludedRepos = getReposFromFile(excludedReposPath);
         for (let i = 0; i < pageCnt; i++) {
             i = i + 1;
-            pagedRepos = await getPagedRepos(token, orgName, i, limit);
+            pagedRepos = await getPagedRepos(request, orgName, i, limit);
             for (let j = 0; j < pagedRepos.length; j++) {
                 repoShortName = pagedRepos[j].replace(orgName + "/","");
                 if(!excludedRepos.includes(repoShortName)) {


### PR DESCRIPTION
Reviewer: @venh 

I recreated PR. The previous conversation history is [here](https://github.com/venh/branch-protection/pull/1).

# Background
I would like to use this action to set a branch protection rules for a repository on GitHub Enterprise server.
But I can't change octokit's GitHub endpoint and also want a mode to set the rules only once.

# Changed
- Be able to change GitHub Base URL with `process.env.GITHUB_API_URL` in each action environment
- Added `add` action (if changing only once)
- Used [request.defaults()](https://github.com/octokit/request.js/#requestdefaults) of `octikit/request.js` to set custom options including token and base url
- Bump up nodejs version 12 to 16 [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- Bump up 1.0.0 to 1.1.0 in package.json
